### PR TITLE
docs: fix Instant Professional Emails steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Perfect for professional emails, chat messages, documents, and social media post
 ### Usage - Instant Professional Emails 
 1. Select text in any application (Outlook or your preferred Mail Tool)
 2. Press `Ctrl+G` (twice)
-3. UI Asstiant opens
+3. UI Assistant opens
 4. Select `Mail | Auto-Detect | Wiki | Memo | Powerpoint`
 5. Click `Process with Pyramidal Agent`
-3. Wait a moment for the AI to process
-4. Your text will be refactored as a draft
+6. Wait a moment for the AI to process
+7. Your text will be refactored as a draft
 
 ## Build Instructions
 


### PR DESCRIPTION
## Summary
- fix typo in Instant Professional Emails instructions
- make step numbers sequential


------
https://chatgpt.com/codex/tasks/task_e_6895ec67c980833183deb1714b7a4c04