### PR TITLE
feat(website): square dot on Fixed, reset kbd letter-spacing in hero

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -51,7 +51,7 @@
     <section class="hero">
       <div class="container">
         <div class="hero-badge">Free & Open Source</div>
-        <h1>Select text<br /><kbd>CTRL+G</kbd><br /><span>Fixed.</span></h1>
+        <h1>Select text<br /><kbd>CTRL+G</kbd><br /><span>Fixed<i class="dot"></i></span></h1>
         <p>Perfect for emails, chat messages, documents, and social media posts. No more copy-pasting between tools — KeyLint fixes your text instantly, wherever you're typing.</p>
         <div class="hero-actions">
           <a class="btn btn-primary" href="https://github.com/0xMMA/KeyLint/releases/download/v3.5.0/FixMyTex_3.5.0_x64-setup.exe">

--- a/website/style.css
+++ b/website/style.css
@@ -116,6 +116,15 @@ nav .container {
   color: var(--primary);
 }
 
+.hero h1 .dot {
+  display: inline-block;
+  width: 0.18em;
+  height: 0.18em;
+  background: var(--primary);
+  margin-left: 0.05em;
+  vertical-align: baseline;
+}
+
 .hero h1 kbd {
   font-family: inherit;
   font-size: inherit;
@@ -124,6 +133,7 @@ nav .container {
   border: none;
   padding: 0;
   color: var(--text-muted);
+  letter-spacing: 0;
 }
 
 .hero p {


### PR DESCRIPTION
## Summary

- Replace period after "Fixed" with a styled square block element (`.dot`) for a sharper visual
- Reset `letter-spacing: 0` on the `CTRL+G` kbd in the hero so it reads naturally against the tighter h1 tracking

## Test plan

- [ ] Verify "Fixed" shows an orange square instead of a round period
- [ ] Verify `CTRL+G` has normal letter-spacing while surrounding text stays tight
- [ ] `build-linux.yml` CI will run automatically

Generated with [Claude Code](https://claude.com/claude-code)