### PR TITLE
chore(docs): SEO hardening, README rewrite, and website fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,80 @@
 # KeyLint
 
-AI-powered text enhancement triggered by a global keyboard shortcut. Select text anywhere, press **Ctrl+G**, and get it fixed instantly.
+[![Build Linux](https://github.com/0xMMA/KeyLint/actions/workflows/build-linux.yml/badge.svg)](https://github.com/0xMMA/KeyLint/actions/workflows/build-linux.yml)
+[![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/0xMMA/KeyLint?include_prereleases)](https://github.com/0xMMA/KeyLint/releases)
+[![GitHub all releases](https://img.shields.io/github/downloads/0xMMA/KeyLint/total)](https://github.com/0xMMA/KeyLint/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## Stack
+**Fix text instantly with AI — one hotkey, perfect writing.**
+
+Perfect for professional emails, chat messages, documents, and social media posts. No more copy-pasting between tools — KeyLint fixes your text instantly, wherever you're typing.
+
+## How It Works
+
+1. **Select** text in any app
+2. Press **Ctrl+G**
+3. **Fixed.** Your text is corrected and written back — no window, no interruption.
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Silent Fix** | Press the hotkey — clipboard text is fixed and written back. No window, no copy-paste loop. |
+| **Deep Enhance** | Open the enhancement panel to rewrite for tone, brevity, or formality. Preview before replacing. |
+| **BYOK** | Bring your own API key. Keys stay in your OS keyring and never leave your machine. |
+| **Multilingual** | Detects the language and corrects without translating. English stays English, German stays German. |
+| **System Tray** | Lives quietly in your system tray. Uses minimal resources. |
+| **Private** | All API calls go through the local Go backend. No telemetry, no cloud sync, no clipboard history stored. |
+
+## Supported AI Providers
+
+- **OpenAI** (GPT-4o, GPT-4, etc.)
+- **Anthropic** (Claude)
+- **Ollama** (local, fully offline)
+- **AWS Bedrock** (Claude, Titan, etc.)
+
+## Installation
+
+1. Download the latest release from [keylint.io](https://keylint.io) or the [Releases](https://github.com/0xMMA/KeyLint/releases/latest) page
+2. Run the installer
+3. Launch KeyLint — the welcome wizard walks you through choosing a provider and entering your API key
+4. Press **Ctrl+G** on any selected text
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request.
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.
+
+---
+
+<details>
+<summary><strong>Development</strong></summary>
+
+### Stack
 
 | Layer | Technology |
-|-------|-----------|
+|-------|------------|
 | Desktop runtime | [Wails v3](https://v3.wails.io/) (Go) |
 | Backend language | Go 1.26 |
 | Dependency injection | [Wire](https://github.com/google/wire) |
 | Frontend | Angular v21 |
 | UI components | PrimeNG v21 (Aura preset, orange/zinc theme) |
-| AI providers | OpenAI, Anthropic Claude, Ollama (local), AWS Bedrock |
 
-## Features
-
-- **Silent mode** — shortcut fires, clipboard text is enhanced and written back, no window shown
-- **UI mode** — enhancement window opens with input/output panels
-- **System tray** — lives quietly in the tray with Open / Exit options
-- **Settings** — per-provider API keys, shortcut key, theme, start-on-boot
-- **Welcome wizard** — guided first-run setup (choose provider → enter key → test)
-- **Dev tools** — simulate the global shortcut from inside the UI (Linux dev)
-
-## Prerequisites
+### Prerequisites
 
 - Go 1.26+
 - Node.js 24 LTS
 - Wails v3 CLI: `go install github.com/wailsapp/wails/v3/cmd/wails3@latest`
+- Linux: `sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev`
+- Windows cross-compilation from Linux: `sudo apt install gcc-mingw-w64`
 
-For Windows cross-compilation from Linux: `sudo apt install gcc-mingw-w64`
-
-## Development
+### Build & Run
 
 ```bash
-# Run with hot reload (Angular dev server + Go binary)
+# Hot-reload dev server (Angular + Go)
 wails3 dev
 
 # Build frontend only
@@ -42,59 +83,55 @@ cd frontend && npm run build
 # Build production binary (Linux)
 go build -tags production -o bin/KeyLint .
 
-# Simulate the global shortcut without a real hotkey (Linux)
-./bin/KeyLint --simulate-shortcut
-```
-
-## Windows Cross-Compilation (from Linux)
-
-```bash
+# Windows cross-compilation
 GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc \
   go build -tags production -ldflags="-w -s -H windowsgui" -o bin/KeyLint.exe .
 ```
 
-## Project Structure
+### Testing
+
+```bash
+# Frontend unit tests (Vitest)
+cd frontend && npm test
+
+# Go unit tests
+go test ./internal/...
+
+# E2E tests (requires ng serve on :4200)
+npx playwright test
+```
+
+### Wire DI Regeneration
+
+```bash
+go install github.com/google/wire/cmd/wire@latest
+wire gen ./internal/app/
+wails3 generate bindings
+```
+
+### Project Structure
 
 ```
 KeyLint/
 ├── main.go                         # Entry point — CLI flags, Wails app setup
-├── go.mod                          # Go module (keylint)
 ├── internal/
-│   ├── app/
-│   │   ├── wire.go                 # Wire DI provider declarations
-│   │   └── wire_gen.go             # Generated by `wire gen ./internal/app/`
-│   └── features/
-│       ├── settings/               # Load/save settings.json
-│       ├── shortcut/               # Global hotkey (Win32 on Windows, stub on Linux)
-│       ├── clipboard/              # Read/write system clipboard
-│       ├── tray/                   # System tray icon + menu
-│       └── welcome/                # First-run detection
+│   ├── app/                        # Wire DI (wire.go + wire_gen.go)
+│   └── features/                   # Vertical slices: settings, shortcut, clipboard, tray, enhance, welcome
 ├── frontend/
 │   ├── src/app/
 │   │   ├── core/                   # WailsService (bindings bridge), MessageBus, guards
-│   │   ├── features/
-│   │   │   ├── text-enhancement/   # Main AI processing UI
-│   │   │   ├── settings/           # Settings form (tabbed)
-│   │   │   ├── welcome-wizard/     # First-run multi-step wizard
-│   │   │   └── dev-tools/          # Simulate shortcut button (dev mode only)
-│   │   └── layout/                 # Sakai-style static sidebar shell
-│   └── bindings/                   # Auto-generated by `wails3 generate bindings`
-├── build/                          # Wails build config + platform Taskfiles
-├── archive/
-│   └── v1-tauri-rust/              # Previous Tauri/Rust implementation
+│   │   ├── features/               # fix, text-enhancement, settings, welcome-wizard, dev-tools
+│   │   └── layout/                 # Sidebar shell
+│   └── bindings/                   # Auto-generated by wails3 generate bindings
+├── website/                        # Landing page (GitHub Pages → keylint.io)
 └── .github/workflows/
     ├── build-linux.yml             # PR/push → Linux binary artifact
     └── build-windows.yml           # Tag push → Windows .exe + draft release
 ```
 
-## Regenerate Wire DI
-
-```bash
-go install github.com/google/wire/cmd/wire@latest
-wire gen ./internal/app/
-```
-
-## CI/CD
+### CI/CD
 
 - **Linux build** — runs on every PR and push to `main`, uploads binary artifact
 - **Windows build** — runs on `v*` tag push, cross-compiles `.exe`, creates a draft GitHub release
+
+</details>

--- a/website/404.html
+++ b/website/404.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Page Not Found — KeyLint</title>
+  <meta name="robots" content="noindex" />
+  <meta name="theme-color" content="#f97316" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⌨️</text></svg>" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <nav>
+    <div class="container">
+      <a href="/" class="nav-brand" style="text-decoration:none">Key<span>Lint</span></a>
+      <ul class="nav-links">
+        <li><a href="/#features">Features</a></li>
+        <li><a href="https://github.com/0xMMA/KeyLint/releases">Download</a></li>
+        <li><a href="https://github.com/0xMMA/KeyLint">GitHub</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main>
+    <section class="hero" style="padding: 120px 0;">
+      <div class="container">
+        <h1 style="margin-bottom: 16px;">404</h1>
+        <p style="margin-bottom: 32px;">This page doesn't exist.</p>
+        <a class="btn btn-primary" href="/">Back to KeyLint</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <span>KeyLint &mdash; open source, MIT license</span>
+      <span>
+        <a href="https://github.com/0xMMA/KeyLint">GitHub</a>
+        &nbsp;&middot;&nbsp;
+        <a href="https://github.com/0xMMA/KeyLint/releases">Releases</a>
+        &nbsp;&middot;&nbsp;
+        <a href="https://github.com/0xMMA/KeyLint/issues">Issues</a>
+      </span>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="One hotkey. Perfect text. Fixes grammar, tone, and style silently in the background." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://keylint.io" />
+  <meta property="og:site_name" content="KeyLint" />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="KeyLint — Fix text instantly with AI" />
   <meta name="twitter:description" content="One hotkey. Perfect text. Fixes grammar, tone, and style silently — no app-switching required." />
@@ -29,6 +30,13 @@
       "priceCurrency": "USD"
     },
     "url": "https://keylint.io",
+    "downloadUrl": "https://github.com/0xMMA/KeyLint/releases/latest",
+    "softwareVersion": "4.1.5-alpha",
+    "author": {
+      "@type": "Organization",
+      "name": "0xMMA",
+      "url": "https://github.com/0xMMA"
+    },
     "description": "AI-powered clipboard text fixer. One hotkey — silent fix, no interruptions.",
     "license": "https://opensource.org/licenses/MIT"
   }
@@ -54,7 +62,7 @@
         <h1>Select text<br /><kbd>CTRL+G</kbd><br /><span>Fixed<i class="dot"></i></span></h1>
         <p>Perfect for emails, chat messages, documents, and social media posts. No more copy-pasting between tools — KeyLint fixes your text instantly, wherever you're typing.</p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="https://github.com/0xMMA/KeyLint/releases/download/v3.5.0/FixMyTex_3.5.0_x64-setup.exe">
+          <a class="btn btn-primary" href="https://github.com/0xMMA/KeyLint/releases/latest">
             Download for Windows
           </a>
           <a class="btn btn-secondary" href="https://github.com/0xMMA/KeyLint">
@@ -131,7 +139,7 @@
       <div class="container">
         <h2>Fix your writing in 60 seconds</h2>
         <p>Download, add your API key, press <kbd>Ctrl+G</kbd>.</p>
-        <a class="btn btn-primary" href="https://github.com/0xMMA/KeyLint/releases/download/v3.5.0/FixMyTex_3.5.0_x64-setup.exe">
+        <a class="btn btn-primary" href="https://github.com/0xMMA/KeyLint/releases/latest">
           Download for Windows
         </a>
       </div>

--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://keylint.io/sitemap.xml

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://keylint.io/</loc>
+    <lastmod>2026-03-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

- **README.md** — Complete rewrite: badges (build, release, downloads, license), one-liner, 3-step how-it-works, feature table, provider list, installation steps, collapsed `<details>` dev section
- **website/index.html** — Add `og:site_name` meta, fix stale download URLs (`v3.5.0/FixMyTex` → `/releases/latest`), enhance JSON-LD with `downloadUrl`, `softwareVersion`, `author`
- **website/robots.txt** — New: Allow all crawlers + sitemap reference
- **website/sitemap.xml** — New: Single-page sitemap for `keylint.io/`
- **website/404.html** — New: Dark-themed 404 page with `noindex`, reuses existing nav/footer
- **GitHub repo metadata** — Set description, homepage (`keylint.io`), and 13 topic tags via `gh` CLI

## Test plan

- [ ] README renders correctly on GitHub with badges, feature table, and collapsed dev section
- [ ] `keylint.io/robots.txt` serves crawler directives after merge
- [ ] `keylint.io/sitemap.xml` returns valid XML after merge
- [ ] Invalid paths (e.g. `keylint.io/nope`) show the 404 page
- [ ] Download buttons on `keylint.io` link to `/releases/latest` (not stale v3.5.0/FixMyTex)
- [ ] View source: `og:site_name` present, JSON-LD includes `downloadUrl`, `softwareVersion`, `author`
- [ ] Repo shows description, homepage link, and topic tags on GitHub
- [ ] `build-linux.yml` CI passes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)