### PR TITLE
chore(docs): update license references to MIT + Commons Clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Linux](https://github.com/0xMMA/KeyLint/actions/workflows/build-linux.yml/badge.svg)](https://github.com/0xMMA/KeyLint/actions/workflows/build-linux.yml)
 [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/0xMMA/KeyLint?include_prereleases)](https://github.com/0xMMA/KeyLint/releases)
 [![GitHub all releases](https://img.shields.io/github/downloads/0xMMA/KeyLint/total)](https://github.com/0xMMA/KeyLint/releases)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![License: MIT + Commons Clause](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue.svg)](LICENSE)
 
 **Fix text instantly with AI — one hotkey, perfect writing.**
 
@@ -46,7 +46,7 @@ Contributions are welcome! Please open an issue or submit a pull request.
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT + Commons Clause — see [LICENSE](LICENSE) for details.
 
 ---
 

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -10,10 +10,10 @@ version: "0.1.0"
 section: "default"
 priority: "extra"
 maintainer: ${GIT_COMMITTER_NAME} <${GIT_COMMITTER_EMAIL}>
-description: "A KeyLint application"
-vendor: "My Company"
-homepage: "https://wails.io"
-license: "MIT"
+description: "AI-powered clipboard text fixer"
+vendor: "KeyLint"
+homepage: "https://keylint.io"
+license: "MIT + Commons Clause"
 release: "1"
 
 contents:

--- a/website/404.html
+++ b/website/404.html
@@ -34,7 +34,7 @@
 
   <footer>
     <div class="container">
-      <span>KeyLint &mdash; open source, MIT license</span>
+      <span>KeyLint &mdash; source available, <a href="https://github.com/0xMMA/KeyLint/blob/main/LICENSE">MIT + Commons Clause</a></span>
       <span>
         <a href="https://github.com/0xMMA/KeyLint">GitHub</a>
         &nbsp;&middot;&nbsp;

--- a/website/index.html
+++ b/website/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>KeyLint — Fix text instantly with AI | One hotkey, perfect writing</title>
-  <meta name="description" content="KeyLint fixes your text instantly with one hotkey. Perfect for emails, chat messages, documents, and social media posts. Supports OpenAI, Anthropic, Ollama, and AWS Bedrock. Free & open source for Windows." />
+  <meta name="description" content="KeyLint fixes your text instantly with one hotkey. Perfect for emails, chat messages, documents, and social media posts. Supports OpenAI, Anthropic, Ollama, and AWS Bedrock. For Windows. Free." />
   <meta name="theme-color" content="#f97316" />
   <meta property="og:title" content="KeyLint — Fix text instantly with AI" />
   <meta property="og:description" content="One hotkey. Perfect text. Fixes grammar, tone, and style silently in the background." />
@@ -38,7 +38,7 @@
       "url": "https://github.com/0xMMA"
     },
     "description": "AI-powered clipboard text fixer. One hotkey — silent fix, no interruptions.",
-    "license": "https://opensource.org/licenses/MIT"
+    "license": "https://github.com/0xMMA/KeyLint/blob/main/LICENSE"
   }
   </script>
 </head>
@@ -58,7 +58,7 @@
   <main>
     <section class="hero">
       <div class="container">
-        <div class="hero-badge">Free & Open Source</div>
+        <div class="hero-badge">Free &amp; Source Available</div>
         <h1>Select text<br /><kbd>CTRL+G</kbd><br /><span>Fixed<i class="dot"></i></span></h1>
         <p>Perfect for emails, chat messages, documents, and social media posts. No more copy-pasting between tools — KeyLint fixes your text instantly, wherever you're typing.</p>
         <div class="hero-actions">
@@ -148,7 +148,7 @@
 
   <footer>
     <div class="container">
-      <span>KeyLint &mdash; open source, MIT license</span>
+      <span>KeyLint &mdash; source available, <a href="https://github.com/0xMMA/KeyLint/blob/main/LICENSE">MIT + Commons Clause</a></span>
       <span>
         <a href="https://github.com/0xMMA/KeyLint">GitHub</a>
         &nbsp;&middot;&nbsp;


### PR DESCRIPTION
## Summary

- Replace all "open source" / "MIT" claims with accurate "source available" / "MIT + Commons Clause" wording
- **website/index.html**: hero badge, meta description, structured data license URL, footer
- **website/404.html**: footer
- **README.md**: license badge and license section
- **build/linux/nfpm/nfpm.yaml**: license field, vendor, homepage, description

No code changes — docs/metadata only. `build-linux.yml` CI will run automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)